### PR TITLE
Change the task to a multitask

### DIFF
--- a/tasks/requirejs_obfuscate.js
+++ b/tasks/requirejs_obfuscate.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
   // Please see the Grunt documentation for more information regarding task
   // creation: http://gruntjs.com/creating-tasks
 
-  grunt.registerTask('requirejs_obfuscate', 'Obfuscate requirejs package names', function() {
+  grunt.registerMultiTask('requirejs_obfuscate', 'Obfuscate requirejs package names', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
       salt: 'salt',


### PR DESCRIPTION
Allow the task to be used for different setups in the same gruntfile.js.

`options` will contain the shared options for the tasks, but can still be run by simply running the `requirejs_obfuscate` task.

But by making it a multitask, you can add "sub tasks" like shown below.

```javascript
grunt.initConfig({
  requirejs_obfuscate: {
    options: {
        dir: 'www/js',
        salt: 'salt',
        root: 'com',
        length: 6,
        quotes: 'double',
        exclude: [
            'lib/require.js',
            'lib/jquery-2.0.3.js'
        ],
        output: false
    },
    beta: {
        dir: 'www/js-beta',
        salt: 'myBetaSalt'
    }
  },
})
```

The options in the "sub tasks" will then override the options in `options` so you can run the `requirejs_obfuscate:beta` to use those other options.