### PR TITLE
Add ability to hash packages that are in either double or single quotes....

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ grunt.initConfig({
         salt: 'salt',
         root: 'com',
         length: 6,
-        quotes: 'double',
+        quotes: 'any',
         exclude: [
             'lib/require.js',
             'lib/jquery-2.0.3.js'
@@ -73,9 +73,9 @@ The length of each hash. Allows a range of 3-16 characters. Higher numbers reduc
 
 #### options.quotes
 Type: `String`
-Default value: `'double'`
+Default value: `'any'`
 
-Set this to whatever your package paths are wrapped with (single or double quotes). You can also set this to "'" or '"'. For example, uglify converts single quotes into double quotes, so if you are not uglifying your code, you might set this to "single" and if you are, you would leave this out or set it to "double".
+Set this to whatever your package paths are wrapped with (single or double quotes) if it is consistent. You can also set this to "'" or '"'. For example, uglify converts single quotes into double quotes, so if you are not uglifying your code, you might set this to "single" and if you are, you would leave this out or set it to "double".
 
 #### options.exclude
 Type: `Array`

--- a/tasks/requirejs_obfuscate.js
+++ b/tasks/requirejs_obfuscate.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
     var options = this.options({
       salt: 'salt',
       exclude: [],
-      quotes: 'double',
+      quotes: 'any',
       length: 6
     });
 
@@ -33,7 +33,8 @@ module.exports = function(grunt) {
       return;
     }
 
-    if (options.quotes == 'double' || options.quotes == '"') options.quotes = '"';
+    if(options.quotes == 'any' || options.quotes == "'|\"" || options.quotes == "\"|'") options.quotes = "'|\"";
+    else if (options.quotes == 'double' || options.quotes == '"') options.quotes = '"';
     else if (options.quotes == 'single' || options.quotes == "'") options.quotes = "'";
     else
     {
@@ -54,7 +55,8 @@ module.exports = function(grunt) {
         var hashed = false;
         for (var p in packages)
         {
-          src = src.split(options.quotes + p + options.quotes).join(options.quotes + packages[p] + options.quotes);
+          var pattern = new RegExp('(' + options.quotes + ')' + p + '\\1', 'g');
+          src = src.replace(pattern, '$1' + packages[p] + '$1');
           //if (options.output) grunt.log.writeln('"' + p + '" > "' + packages[p] + '"');
           hashed = true;
         }


### PR DESCRIPTION
... Make this the default behavior. This fixes issues where package path is not hashed if user was inconsistent with use of quotes and the resulting error when the file is not found by its original path.